### PR TITLE
Episodes and Shows functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage
 coverage.lcov
 types
 .DS_Store
+.idea

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -6,4 +6,5 @@ export * from "./market/market.endpoints";
 export * from "./playlist/playlist.endpoints";
 export * from "./track/track.endpoints";
 export * from "./user/user.endpoints";
+export * from "./episode/episode.endpoints";
 export { search, type SearchOpts } from "./search/search.endpoints";

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -7,4 +7,5 @@ export * from "./playlist/playlist.endpoints";
 export * from "./track/track.endpoints";
 export * from "./user/user.endpoints";
 export * from "./episode/episode.endpoints";
+export * from "./show/show.endpoints";
 export { search, type SearchOpts } from "./search/search.endpoints";

--- a/src/api/episode/episode.endpoints.ts
+++ b/src/api/episode/episode.endpoints.ts
@@ -1,55 +1,95 @@
-import {HTTPClient} from "../client";
-import {Market} from "../market/market.types";
-import {Episode} from "../episode/episode.types"
-import {PagingObject, PagingOptions} from "../general.types";
+import { HTTPClient } from "../client";
+import { Market } from "../market/market.types";
+import { Episode } from "../episode/episode.types";
+import { PagingObject, PagingOptions } from "../general.types";
 
 export const getEpisode = async (
-    client: HTTPClient,
-    episode_id: string,
-    market?: Market
+  client: HTTPClient,
+  episode_id: string,
+  market?: Market
 ) => {
-    return await client.fetch<Episode>("/episodes/" + episode_id, "json", {
-        query: {market}
-    });
+  return await client.fetch<Episode>("/episodes/" + episode_id, "json", {
+    query: { market }
+  });
 };
 
 export const getEpisodes = async (
-    client: HTTPClient,
-    episodes_ids: string[],
-    market?: Market
+  client: HTTPClient,
+  episodes_ids: string[],
+  market?: Market
 ) => {
-    return (
-        await client.fetch<{episodes: Episode[]}>("/episodes", "json", {
-            query: {market, ids: episodes_ids}
-        })
-    ).episodes
-}
+  return (
+    await client.fetch<{ episodes: Episode[] }>("/episodes", "json", {
+      query: { market, ids: episodes_ids }
+    })
+  ).episodes;
+};
 
 export interface GetSavedEpisodesOpts extends PagingOptions {
-    market?: Market;
+  market?: Market;
 }
 
 export const getSavedEpisodes = async (
-    client: HTTPClient,
-    opts?: GetSavedEpisodesOpts
+  client: HTTPClient,
+  opts?: GetSavedEpisodesOpts
 ) => {
-    return await client.fetch<
-        PagingObject<{
-            added_at: string;
-            episode: Episode
-        }>
-    >("/me/episodes", "json", {
-        query: opts
-    });
+  return await client.fetch<
+    PagingObject<{
+      added_at: string;
+      episode: Episode;
+    }>
+  >("/me/episodes", "json", {
+    query: opts
+  });
 };
 
-export const saveEpisodes = async (client: HTTPClient, episodes_ids: string[]) => {
-    await client.fetch("/me/episodes", "void", {
-        method: "PUT",
-        query: {ids: episodes_ids}
-    });
+export const saveEpisodes = async (
+  client: HTTPClient,
+  episodes_ids: string[]
+) => {
+  await client.fetch("/me/episodes", "void", {
+    method: "PUT",
+    query: { ids: episodes_ids }
+  });
 };
 
 export const saveEpisode = async (client: HTTPClient, episode_id: string) => {
-    await saveEpisodes(client, [episode_id])EEE
-}
+  await saveEpisodes(client, [episode_id]);
+};
+
+export const removeSavedEpisodes = async (
+  client: HTTPClient,
+  episodes_ids: string[]
+) => {
+  await client.fetch("/me/episodes", "void", {
+    method: "DELETE",
+    query: {
+      ids: episodes_ids
+    }
+  });
+};
+
+export const removeSavedEpisode = async (
+  client: HTTPClient,
+  episodes_id: string
+) => {
+  await removeSavedEpisodes(client, [episodes_id]);
+};
+
+export const checkSavedEpisodes = async (
+  client: HTTPClient,
+  episodes_ids: string[]
+) => {
+  return await client.fetch<boolean[]>("/me/albums/contains", "json", {
+    query: {
+      ids: episodes_ids
+    }
+  });
+};
+
+export const checkSaveEpisode = async (
+  client: HTTPClient,
+  episode_id: string
+) => {
+  return (await checkSavedEpisodes(client, [episode_id]))[0];
+};

--- a/src/api/episode/episode.endpoints.ts
+++ b/src/api/episode/episode.endpoints.ts
@@ -1,0 +1,55 @@
+import {HTTPClient} from "../client";
+import {Market} from "../market/market.types";
+import {Episode} from "../episode/episode.types"
+import {PagingObject, PagingOptions} from "../general.types";
+
+export const getEpisode = async (
+    client: HTTPClient,
+    episode_id: string,
+    market?: Market
+) => {
+    return await client.fetch<Episode>("/episodes/" + episode_id, "json", {
+        query: {market}
+    });
+};
+
+export const getEpisodes = async (
+    client: HTTPClient,
+    episodes_ids: string[],
+    market?: Market
+) => {
+    return (
+        await client.fetch<{episodes: Episode[]}>("/episodes", "json", {
+            query: {market, ids: episodes_ids}
+        })
+    ).episodes
+}
+
+export interface GetSavedEpisodesOpts extends PagingOptions {
+    market?: Market;
+}
+
+export const getSavedEpisodes = async (
+    client: HTTPClient,
+    opts?: GetSavedEpisodesOpts
+) => {
+    return await client.fetch<
+        PagingObject<{
+            added_at: string;
+            episode: Episode
+        }>
+    >("/me/episodes", "json", {
+        query: opts
+    });
+};
+
+export const saveEpisodes = async (client: HTTPClient, episodes_ids: string[]) => {
+    await client.fetch("/me/episodes", "void", {
+        method: "PUT",
+        query: {ids: episodes_ids}
+    });
+};
+
+export const saveEpisode = async (client: HTTPClient, episode_id: string) => {
+    await saveEpisodes(client, [episode_id])EEE
+}

--- a/src/api/episode/episode.endpoints.ts
+++ b/src/api/episode/episode.endpoints.ts
@@ -3,6 +3,13 @@ import { Market } from "../market/market.types";
 import { Episode } from "../episode/episode.types";
 import { PagingObject, PagingOptions } from "../general.types";
 
+/**
+ * Get Spotify catalog informnation for a single episode.
+ *
+ * @param client Spotify HTTPClient
+ * @param episode_id The Spotify ID of the episode
+ * @param market An ISO 3166-1 alpha-2 country code
+ */
 export const getEpisode = async (
   client: HTTPClient,
   episode_id: string,
@@ -13,6 +20,13 @@ export const getEpisode = async (
   });
 };
 
+/**
+ * Get spotify catalog information for multiple episodes identified by their Spotify IDs.
+ *
+ * @param client Spotify HTTPClient
+ * @param episodes_ids List of the Spotify IDs of the episodes. Maximum: 20 IDs
+ * @param market An ISO 3166-1 alpha-2 country code
+ */
 export const getEpisodes = async (
   client: HTTPClient,
   episodes_ids: string[],
@@ -26,16 +40,32 @@ export const getEpisodes = async (
 };
 
 export interface GetSavedEpisodesOpts extends PagingOptions {
+  /**
+   * An ISO 3166-1 alpha-2 country code.
+   * If a country code is specified, only content that is available in that market will be returned.
+   */
   market?: Market;
 }
 
+/**
+ * Get a list of the episodes saved in the current Spotify user's 'Your Shows' library.
+ *
+ * @param client Spotify HTTPClient
+ * @param opts Additional option for request
+ */
 export const getSavedEpisodes = async (
   client: HTTPClient,
   opts?: GetSavedEpisodesOpts
 ) => {
   return await client.fetch<
     PagingObject<{
+      /**
+       * The date and time the episode was saved Timestamps are returned in ISO 8601 format as Coordinated Universal Time (UTC) with a zero offset: YYYY-MM-DDTHH:MM:SSZ.
+       */
       added_at: string;
+      /**
+       * Information about the episode.
+       */
       episode: Episode;
     }>
   >("/me/episodes", "json", {
@@ -43,6 +73,12 @@ export const getSavedEpisodes = async (
   });
 };
 
+/**
+ * Save one or more episodes to the current user's 'Your Music' library.
+ *
+ * @param client Spotify HTTPClient
+ * @param episodes_ids List of the Spotify IDs for the episodes. Maximum: 20 IDs
+ */
 export const saveEpisodes = async (
   client: HTTPClient,
   episodes_ids: string[]
@@ -53,10 +89,22 @@ export const saveEpisodes = async (
   });
 };
 
+/**
+ * Save episode to the current user's 'Your Shows' library.
+ *
+ * @param client Spotify HTTPClient
+ * @param episode_id The Spotify ID of the episode
+ */
 export const saveEpisode = async (client: HTTPClient, episode_id: string) => {
   await saveEpisodes(client, [episode_id]);
 };
 
+/**
+ * Remove one or more episodes from the current user's 'Your Shows' library.
+ *
+ * @param client Spotify HTTPClient
+ * @param episodes_ids List of the Spotify IDs for the episodes. Maximum: 20 IDs
+ */
 export const removeSavedEpisodes = async (
   client: HTTPClient,
   episodes_ids: string[]
@@ -69,6 +117,12 @@ export const removeSavedEpisodes = async (
   });
 };
 
+/**
+ * Remove episode from the current user's 'Your Shows' library.
+ *
+ * @param client Spotify HTTPClient
+ * @param episodes_id List of the Spotify IDs for the episodes. Maximum: 20 IDs
+ */
 export const removeSavedEpisode = async (
   client: HTTPClient,
   episodes_id: string
@@ -76,6 +130,12 @@ export const removeSavedEpisode = async (
   await removeSavedEpisodes(client, [episodes_id]);
 };
 
+/**
+ * Check if one or more episodes is already saved in the current Spotify user's 'Your Shows' library.
+ *
+ * @param client Spotify HTTPClient
+ * @param episodes_ids List of the Spotify IDs for the episodes. Maximum: 20 IDs
+ */
 export const checkSavedEpisodes = async (
   client: HTTPClient,
   episodes_ids: string[]
@@ -87,6 +147,12 @@ export const checkSavedEpisodes = async (
   });
 };
 
+/**
+ * Check if epsisode is already saved in the current Spotify user's 'Your Shows' library.
+ *
+ * @param client Spotify HTTPClient
+ * @param episode_id The Spotify ID for the episode
+ */
 export const checkSaveEpisode = async (
   client: HTTPClient,
   episode_id: string

--- a/src/api/episode/episode.types.ts
+++ b/src/api/episode/episode.types.ts
@@ -9,30 +9,101 @@ import {
 import { Show } from "../show/show.types";
 
 export interface EpisodeSimplified extends JSONObject {
+  /**
+   * A URL to a 30 second preview (MP3 format).
+   */
   audio_preview_url: string;
+
+  /**
+   * A description of the episode without HTML tags.
+   */
   description: string;
+  /**
+   * A description of the episode with HTML tags.
+   */
   html_description: string;
+  /**
+   * The episode length in milliseconds.
+   */
   duration_ms: number;
+  /**
+   * Whether or not the episode has explicit lyrics.
+   */
   explicit: boolean;
+  /**
+   * External URLs for this episode.
+   */
   external_urls: ExternalUrls;
+  /**
+   * A link to the Web API endpoint providing full details of the episode.
+   */
   href: string;
+  /**
+   * The Spotify ID for the episode.
+   */
   id: string;
+  /**
+   * Images of the episode in various sizes, widest first.
+   */
   images: Image[];
+  /**
+   * True, if the episode is hosted outside of Spotify's CDN.
+   */
   is_externally_hosted: boolean;
+  /**
+   * If true, the episode is playable in the given market.
+   * Otherwise false.
+   */
   is_playable: boolean;
+  /**
+   * The language used in the episode. Identified by a ISO 639 code. Deprecated.
+   */
   language?: string;
+  /**
+   * A list of the languages used in the episode, identified by their ISO 639-1 code.
+   */
   languages: string[];
+  /**
+   * The name of the episode.
+   */
   name: string;
+  /**
+   * The date the episode was first released.
+   * Depending on the precision it might be shown in different ways
+   */
   release_date: string;
-  release_date_precision: string;
+  /**
+   * The precision with which `release_date` value is known.
+   */
+  release_date_precision: "year" | "month" | "day";
+  /**
+   * The user's most recent position in the episode.
+   */
   resume_point: ResumePoint;
+  /**
+   * The object type.
+   */
   type: "episode";
+  /**
+   * The Spotify URI for the episode.
+   */
   url: string;
+  /**
+   * Included in the response when a content restriction is applied.
+   */
   restrictions?: {
+    /**
+     * The reason for the restriction.
+     *
+     * Episodes may be restricted if the content is not available in a given market, to the user's subscription type, or when the user's account is set to not play explicit content.
+     */
     reason: RestrictionsReason;
   };
 }
 
 export interface Episode extends EpisodeSimplified, JSONObject {
+  /**
+   * The show on which episode belongs.
+   */
   show: Show;
 }

--- a/src/api/episode/episode.types.ts
+++ b/src/api/episode/episode.types.ts
@@ -1,53 +1,38 @@
-import {JSONObject} from "../../shared";
-import {Copyright, ExternalUrls, Image, RestrictionsReason, ResumePoint} from "../general.types";
-import {Market} from "../market/market.types";
+import { JSONObject } from "../../shared";
+import {
+  Copyright,
+  ExternalUrls,
+  Image,
+  RestrictionsReason,
+  ResumePoint
+} from "../general.types";
+import { Show } from "../show/show.types";
 
-
-interface EpisodeBase extends JSONObject {
-    audio_preview_url: string;
-    description: string;
-    html_description: string;
-    duration_ms: number;
-    explicit: boolean;
-    external_urls: ExternalUrls;
-    href: string;
-    id: string;
-    images: Image[];
-    is_externally_hosted: boolean;
-    is_playable: boolean;
-    language?: string;
-    languages: string[];
-    name: string;
-    release_date: string;
-    release_date_precision: string;
-    resume_point: ResumePoint;
-    type: "episode";
-    url: string;
-    restrictions?: {
-        reason: RestrictionsReason;
-    }
+export interface EpisodeSimplified extends JSONObject {
+  audio_preview_url: string;
+  description: string;
+  html_description: string;
+  duration_ms: number;
+  explicit: boolean;
+  external_urls: ExternalUrls;
+  href: string;
+  id: string;
+  images: Image[];
+  is_externally_hosted: boolean;
+  is_playable: boolean;
+  language?: string;
+  languages: string[];
+  name: string;
+  release_date: string;
+  release_date_precision: string;
+  resume_point: ResumePoint;
+  type: "episode";
+  url: string;
+  restrictions?: {
+    reason: RestrictionsReason;
+  };
 }
 
-interface Show extends JSONObject {
-    available_markets: Market[];
-    copyrights: Copyright[];
-    description: string;
-    html_description: string;
-    explicit: boolean;
-    external_urls: ExternalUrls;
-    href: string
-    id: string;
-    images: Image[];
-    is_externally_hosted: boolean;
-    languages: string[];
-    media_type: string;
-    name: string;
-    publisher: string;
-    type: string;
-    url: string;
-    total_episodes: number;
-}
-
-export interface Episode extends EpisodeBase, JSONObject {
-    show: Show;
+export interface Episode extends EpisodeSimplified, JSONObject {
+  show: Show;
 }

--- a/src/api/episode/episode.types.ts
+++ b/src/api/episode/episode.types.ts
@@ -1,0 +1,53 @@
+import {JSONObject} from "../../shared";
+import {Copyright, ExternalUrls, Image, RestrictionsReason, ResumePoint} from "../general.types";
+import {Market} from "../market/market.types";
+
+
+interface EpisodeBase extends JSONObject {
+    audio_preview_url: string;
+    description: string;
+    html_description: string;
+    duration_ms: number;
+    explicit: boolean;
+    external_urls: ExternalUrls;
+    href: string;
+    id: string;
+    images: Image[];
+    is_externally_hosted: boolean;
+    is_playable: boolean;
+    language?: string;
+    languages: string[];
+    name: string;
+    release_date: string;
+    release_date_precision: string;
+    resume_point: ResumePoint;
+    type: "episode";
+    url: string;
+    restrictions?: {
+        reason: RestrictionsReason;
+    }
+}
+
+interface Show extends JSONObject {
+    available_markets: Market[];
+    copyrights: Copyright[];
+    description: string;
+    html_description: string;
+    explicit: boolean;
+    external_urls: ExternalUrls;
+    href: string
+    id: string;
+    images: Image[];
+    is_externally_hosted: boolean;
+    languages: string[];
+    media_type: string;
+    name: string;
+    publisher: string;
+    type: string;
+    url: string;
+    total_episodes: number;
+}
+
+export interface Episode extends EpisodeBase, JSONObject {
+    show: Show;
+}

--- a/src/api/general.types.ts
+++ b/src/api/general.types.ts
@@ -99,7 +99,13 @@ export interface Image extends JSONObject {
 }
 
 export interface ResumePoint extends JSONObject {
+  /**
+   * Whether or not the episode has been fully played by the user.
+   */
   fully_played: boolean;
+  /**
+   * The user's most recent position in the episode in milliseconds
+   */
   resume_position_ms: number;
 }
 

--- a/src/api/general.types.ts
+++ b/src/api/general.types.ts
@@ -98,6 +98,11 @@ export interface Image extends JSONObject {
   width: number | null;
 }
 
+export interface ResumePoint extends JSONObject {
+  fully_played: boolean;
+  resume_position_ms: number;
+}
+
 export interface Followers extends JSONObject {
   /**
    * This will always be set to null, as the Web API does not support it at the moment.

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -8,6 +8,7 @@ export * from "./track/track.types";
 export * from "./user/user.types";
 export * from "./search/search.types";
 export * from "./episode/episode.types";
+export * from "./show/show.types";
 
 export * from "./endpoints";
 export * from "./general.types";

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -7,6 +7,7 @@ export * from "./playlist/playlist.types";
 export * from "./track/track.types";
 export * from "./user/user.types";
 export * from "./search/search.types";
+export * from "./episode/episode.types";
 
 export * from "./endpoints";
 export * from "./general.types";

--- a/src/api/show/show.endpoints.ts
+++ b/src/api/show/show.endpoints.ts
@@ -1,0 +1,171 @@
+import { HTTPClient } from "../client";
+import { EpisodeSimplified } from "../episode/episode.types";
+import { PagingObject, PagingOptions } from "../general.types";
+import { Market } from "../market/market.types";
+import { Show, ShowSimplified } from "./show.types";
+
+/**
+ * Get spotify catalog information for a single show by its unique Spotify ID.
+ *
+ * @param client Spotify HTTPClient
+ * @param show_id The Spotify ID of the show
+ * @param market An ISO 3166-1 alpha-2 country code
+ */
+export const getShow = async (
+  client: HTTPClient,
+  show_id: string,
+  market?: Market
+) => {
+  return await client.fetch<Show>("/shows/" + show_id, "json", {
+    query: { market }
+  });
+};
+
+/**
+ * Get spotify catalog information for multiple shows by their Spotify IDs.
+ *
+ * @param client Spotify HTTPClient
+ * @param show_ids List of the Spotify IDs for the shows. Maximum: 20 IDs
+ * @param market An ISO 3166-1 alpha-2 country code
+ */
+export const getShows = async (
+  client: HTTPClient,
+  show_ids: string[],
+  market?: Market
+) => {
+  return (
+    await client.fetch<{ shows: ShowSimplified }>("/shows", "json", {
+      query: { market, ids: show_ids }
+    })
+  ).shows;
+};
+
+export interface GetShowTrackOpts extends PagingOptions {
+  /**
+   * An ISO 3166-1 alpha-2 country code.
+   * If a country code is specified, only content that is available in that market will be returned.
+   */
+  market?: Market;
+}
+
+/**
+ * Get Spotify catalog information about an show's episodes.
+ * Optional parameters can be used to limit the number of episodes returned.
+ *
+ * @param client Spotify HTTPClient
+ * @param show_id The Spotify ID of the show
+ * @param opts Additional option for request
+ */
+export const getShowEpisodes = async (
+  client: HTTPClient,
+  show_id: string,
+  opts?: GetShowTrackOpts
+) => {
+  return await client.fetch<PagingObject<EpisodeSimplified>>(
+    `/shows/${show_id}/episodes`,
+    "json",
+    {
+      query: opts
+    }
+  );
+};
+
+export interface GetSavedShowsOpts extends PagingOptions {
+  /**
+   * An ISO 3166-1 alpha-2 country code.
+   * If a country code is specified, only content that is available in that market will be returned.
+   */
+  market?: Market;
+}
+/**
+ *
+ * @param client  Spotify HTTPClient
+ * @param opts Additional option for request
+ */
+export const getSavedShows = async (
+  client: HTTPClient,
+  opts?: GetSavedShowsOpts
+) => {
+  return await client.fetch<
+    PagingObject<{
+      added_at: string;
+      show: Show;
+    }>
+  >("/me/shows", "json", {
+    query: opts
+  });
+};
+
+/**
+ *
+ * @param client Spotify HTTPClient
+ * @param shows_ids List of the Spotify IDs for the shows. Maximum: 20
+ */
+export const saveShows = async (client: HTTPClient, shows_ids: string[]) => {
+  await client.fetch("/me/shows", "void", {
+    method: "PUT",
+    query: { ids: shows_ids }
+  });
+};
+
+/**
+ *
+ * @param client  Spotify HTTPClient
+ * @param show_id The Spotify ID of the show
+ */
+export const saveShow = async (client: HTTPClient, show_id: string) => {
+  await saveShows(client, [show_id]);
+};
+
+/**
+ *
+ * @param client Spotify HTTPClient
+ * @param show_ids List of the Spotify IDs for the shows. Maximum: 20
+ */
+export const removeSavedShows = async (
+  client: HTTPClient,
+  show_ids: string[]
+) => {
+  await client.fetch("/me/shows", "void", {
+    method: "DELETE",
+    query: {
+      ids: show_ids
+    }
+  });
+};
+
+/**
+ * Remove show from the current user's 'Your Shows' library.
+ *
+ * @param client Spotify HTTPClient
+ * @param show_id The Spotify ID of the show
+ */
+export const removeSavedShow = async (client: HTTPClient, show_id: string) => {
+  await removeSavedShows(client, [show_id]);
+};
+
+/**
+ * Check if one or more shows is already saved in the current Spotify users' 'Your Shows' library.
+ *
+ * @param client Spotify HTTPClient
+ * @param show_ids List of the Spotify IDs for the shows. Maximum: 20
+ */
+export const checkSavedShows = async (
+  client: HTTPClient,
+  show_ids: string[]
+) => {
+  return await client.fetch<boolean[]>("/me/shows/contains", "json", {
+    query: {
+      ids: show_ids
+    }
+  });
+};
+
+/**
+ * Check if show is already saved in the current Spotify user's 'Your Shows' library.
+ * @param client Spotify HTTPClient
+ * @param show_id The Spotify ID of the show
+ */
+export const checkSavedShow = async (client: HTTPClient, show_id: string) => {
+  return (await checkSavedShows(client, [show_id]))[0];
+};

--- a/src/api/show/show.types.ts
+++ b/src/api/show/show.types.ts
@@ -4,25 +4,79 @@ import { Copyright, ExternalUrls, Image, PagingObject } from "../general.types";
 import { Market } from "../market/market.types";
 
 export interface ShowSimplified extends JSONObject {
+  /**
+   * A list of the countries in which the track can be played.
+   */
   available_markets: Market[];
+  /**
+   * The copyright statements of the show.
+   */
   copyrights: Copyright[];
+  /**
+   * The description of the show without html tags.
+   */
   description: string;
+  /**
+   * The description of the show with html tags.
+   */
   html_description: string;
+  /**
+   * Whether or not the show has explicit lyrics.
+   */
   explicit: boolean;
+  /**
+   * External URLs for this show.
+   */
   external_urls: ExternalUrls;
+  /**
+   * A link to the Web API endpoint providing full details of the show.
+   */
   href: string;
+  /**
+   * The Spotify ID for the show.
+   */
   id: string;
+  /**
+   * Images of the show in various sizes, widest first.
+   */
   images: Image[];
+  /**
+   * True, if the episode is hosted outside of Spotify's CDN.
+   */
   is_externally_hosted: boolean;
+  /**
+   * A list of the languages used in the episode, identified by their ISO 639-1 code.
+   */
   languages: string[];
+  /**
+   * The media type of the show.
+   */
   media_type: string;
+  /**
+   * The name of the episode.
+   */
   name: string;
+  /**
+   * The publisher of the show.
+   */
   publisher: string;
-  type: string;
+  /**
+   * THe object type.
+   */
+  type: "show";
+  /**
+   * The Spotify URI for the show.
+   */
   url: string;
+  /**
+   * The total number of episodes in the show.
+   */
   total_episodes: number;
 }
 
 export interface Show extends ShowSimplified, JSONObject {
+  /**
+   * The episodes of the show.
+   */
   episodes: PagingObject<EpisodeSimplified>;
 }

--- a/src/api/show/show.types.ts
+++ b/src/api/show/show.types.ts
@@ -1,0 +1,28 @@
+import { JSONObject } from "../../shared";
+import { EpisodeSimplified } from "../episode/episode.types";
+import { Copyright, ExternalUrls, Image, PagingObject } from "../general.types";
+import { Market } from "../market/market.types";
+
+export interface ShowSimplified extends JSONObject {
+  available_markets: Market[];
+  copyrights: Copyright[];
+  description: string;
+  html_description: string;
+  explicit: boolean;
+  external_urls: ExternalUrls;
+  href: string;
+  id: string;
+  images: Image[];
+  is_externally_hosted: boolean;
+  languages: string[];
+  media_type: string;
+  name: string;
+  publisher: string;
+  type: string;
+  url: string;
+  total_episodes: number;
+}
+
+export interface Show extends ShowSimplified, JSONObject {
+  episodes: PagingObject<EpisodeSimplified>;
+}


### PR DESCRIPTION
Partly resolved #36 I implemented episodes and shows Spotify API functions, they are pretty much the same as album + tracks. So, the code is very close to them.

The steps I did:
1. Saw how you implemented the same logic inside album and tracks.
2. Created types for episode and track, which is close to album and tracks.
3. Created new functions, that implements logic from episodes and tracks chapters of Spotify Docs.
4. Also, I tested it a bit by hands and it seems to work good.
5. Wrote some docs for new functionality.
6. Run pnpm lint and default tests.