### PR TITLE
fix: fixed inaccurate saved tracks return type

### DIFF
--- a/endpoints/track/track.endpoints.ts
+++ b/endpoints/track/track.endpoints.ts
@@ -68,11 +68,13 @@ export type GetSavedTracksOpts = Prettify<
 export const getSavedTracks = async (
 	client: HTTPClient,
 	options: GetSavedTracksOpts,
-): Promise<PagingObject<Track>> => {
+): Promise<PagingObject<{ added_at: string; track: Track }>> => {
 	const res = await client.fetch("/v1/me/tracks", {
 		query: options,
 	});
-	return res.json() as Promise<PagingObject<Track>>;
+	return res.json() as Promise<
+		PagingObject<{ added_at: string; track: Track }>
+	>;
 };
 
 /**


### PR DESCRIPTION
I noticed that the return type of `getSavedTracks` was inaccurate, since it doesn't just return the track object in the response `items` array, but it returns an object with an `added_at` timestamp and `track` object.

See Spotify Web API documentation I referenced: https://developer.spotify.com/documentation/web-api/reference/get-users-saved-tracks